### PR TITLE
Support use of "job_id" instead of "id"

### DIFF
--- a/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit_superstaq/superstaq_backend.py
@@ -130,12 +130,12 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
         res.raise_for_status()
         response = res.json()
-        if "ss_ids" not in response:
+        if "job_ids" not in response:
             raise Exception
 
         #  we make a virtual job_id that aggregates all of the individual jobs
         # into a single one, that comma-separates the individual jobs:
-        job_id = ",".join(response["ss_ids"])
+        job_id = ",".join(response["job_ids"])
         job = qss.superstaq_job.SuperstaQJob(self, job_id)
 
         return job

--- a/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit_superstaq/superstaq_backend.py
@@ -130,12 +130,12 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
         res.raise_for_status()
         response = res.json()
-        if "ids" not in response:
+        if "ss_ids" not in response:
             raise Exception
 
         #  we make a virtual job_id that aggregates all of the individual jobs
         # into a single one, that comma-separates the individual jobs:
-        job_id = ",".join(response["ids"])
+        job_id = ",".join(response["ss_ids"])
         job = qss.superstaq_job.SuperstaQJob(self, job_id)
 
         return job

--- a/qiskit_superstaq/superstaq_backend_test.py
+++ b/qiskit_superstaq/superstaq_backend_test.py
@@ -137,8 +137,8 @@ def test_default_options() -> None:
 
 
 class MockResponse:
-    def __init__(self, ids: List[str]) -> None:
-        self.content = json.dumps({"ss_ids": ids})
+    def __init__(self, job_ids: List[str]) -> None:
+        self.content = json.dumps({"job_ids": job_ids})
 
     def json(self) -> Dict:
         return json.loads(self.content)

--- a/qiskit_superstaq/superstaq_backend_test.py
+++ b/qiskit_superstaq/superstaq_backend_test.py
@@ -138,7 +138,7 @@ def test_default_options() -> None:
 
 class MockResponse:
     def __init__(self, ids: List[str]) -> None:
-        self.content = json.dumps({"ids": ids})
+        self.content = json.dumps({"ss_ids": ids})
 
     def json(self) -> Dict:
         return json.loads(self.content)

--- a/qiskit_superstaq/superstaq_job.py
+++ b/qiskit_superstaq/superstaq_job.py
@@ -32,9 +32,8 @@ class SuperstaQJob(qiskit.providers.JobV1):
 
         Parameters:
             backend (BaseBackend): Backend that job was executed on.
-            job_id (str): The unique job ID.
-            access_token (str): The AQT access token.
-            qobj (Qobj): Quantum object, if any.
+            job_id (str): The unique job ID from SuperstaQ.
+            access_token (str): The access token.
         """
         super().__init__(backend, job_id)
 


### PR DESCRIPTION
SuperstaQ API now returns a "job_id" (or "job_ids") key. These changes are needed to comply with the new API.