### PR TITLE
cirq-superstaq to `requirements.txt` and downgrade required  python to  `python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 qiskit
 cirq
+cirq-superstaq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-qiskit
 cirq
 cirq-superstaq
+qiskit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 cirq
-cirq-superstaq
 qiskit

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url="https://github.com/SupertechLabs/qiskit-superstaq",
     author="Super.tech",
     author_email="pranav@super.tech",
-    python_requires=(">=3.8.0"),
+    python_requires=(">=3.7.0"),
     install_requires=requirements,
     license="N/A",
     description=description,


### PR DESCRIPTION
`qiskit-superstaq` already had `cirq` as a dependency so it's wasn't independent from `cirq` in the first place. I don't see big downsides to adding `cirq-superstaq` as well. We also won't have to duplicate things like https://github.com/SupertechLabs/cirq-superstaq/pull/9 if we did this.