### PR TITLE
Fixing compile inputs for `daily_integration`

### DIFF
--- a/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit_superstaq/superstaq_provider.py
@@ -159,7 +159,9 @@ class SuperstaQProvider(
         serialized_circuits = qss.serialization.serialize_circuits(circuits)
         circuits_list = not isinstance(circuits, qiskit.QuantumCircuit)
 
-        json_dict = self._client.aqt_compile({"qiskit_circuits": serialized_circuits}, target)
+        json_dict = self._client.aqt_compile(
+            {"qiskit_circuits": serialized_circuits, "backend": target}
+        )
 
         from qiskit_superstaq import compiler_output
 
@@ -182,7 +184,9 @@ class SuperstaQProvider(
         """
         serialized_circuits = qss.serialization.serialize_circuits(circuits)
         circuits_list = not isinstance(circuits, qiskit.QuantumCircuit)
-        json_dict = self._client.qscout_compile({"qiskit_circuits": serialized_circuits}, target)
+        json_dict = self._client.qscout_compile(
+            {"qiskit_circuits": serialized_circuits, "backend": target}
+        )
 
         from qiskit_superstaq import compiler_output
 


### PR DESCRIPTION
Changed compile input parameters to match what universal circuit model expects: target should be passed in as a value to the `backend` keyword.

![qss-daily-integration](https://user-images.githubusercontent.com/18367737/143911896-102f6b8f-1dbe-4735-a59e-dd84c46aed27.png)