### PR TITLE
Hide environment variable

### DIFF
--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -12,12 +12,9 @@ import qiskit_superstaq as qss
 def test_provider() -> None:
     ss_provider = qss.superstaq_provider.SuperstaQProvider(api_key="MY_TOKEN")
 
-    env_api_key = os.environ.pop("SUPERSTAQ_API_KEY", None)
+    _ = os.environ.pop("SUPERSTAQ_API_KEY", None)
     with pytest.raises(EnvironmentError, match="api_key was not "):
         qss.superstaq_provider.SuperstaQProvider()
-
-    if env_api_key is not None:
-        os.environ["SUPERSTAQ_API_KEY"] = env_api_key
 
     assert str(ss_provider.get_backend("ibmq_qasm_simulator")) == str(
         qss.superstaq_backend.SuperstaQBackend(

--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -1,5 +1,5 @@
-import os
 import textwrap
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import applications_superstaq
@@ -9,10 +9,10 @@ import qiskit
 import qiskit_superstaq as qss
 
 
-def test_provider(monkeypatch) -> None:
+def test_provider(monkeypatch: Any) -> None:
     ss_provider = qss.superstaq_provider.SuperstaQProvider(api_key="MY_TOKEN")
 
-    monkeypatch.delenv("SUPERSTAQ_API_KEY")
+    monkeypatch.delenv("SUPERSTAQ_API_KEY", raising=False)
     with pytest.raises(EnvironmentError, match="api_key was not "):
         qss.superstaq_provider.SuperstaQProvider()
 

--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -1,5 +1,5 @@
+import os
 import textwrap
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import applications_superstaq
@@ -9,10 +9,10 @@ import qiskit
 import qiskit_superstaq as qss
 
 
-def test_provider(monkeypatch: Any) -> None:
+@patch.dict(os.environ, {"SUPERSTAQ_API_KEY": ""})
+def test_provider() -> None:
     ss_provider = qss.superstaq_provider.SuperstaQProvider(api_key="MY_TOKEN")
 
-    monkeypatch.delenv("SUPERSTAQ_API_KEY", raising=False)
     with pytest.raises(EnvironmentError, match="api_key was not "):
         qss.superstaq_provider.SuperstaQProvider()
 

--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 from unittest.mock import MagicMock, patch
 
@@ -11,8 +12,12 @@ import qiskit_superstaq as qss
 def test_provider() -> None:
     ss_provider = qss.superstaq_provider.SuperstaQProvider(api_key="MY_TOKEN")
 
+    env_api_key = os.environ.pop("SUPERSTAQ_API_KEY", None)
     with pytest.raises(EnvironmentError, match="api_key was not "):
         qss.superstaq_provider.SuperstaQProvider()
+
+    if env_api_key is not None:
+        os.environ["SUPERSTAQ_API_KEY"] = env_api_key
 
     assert str(ss_provider.get_backend("ibmq_qasm_simulator")) == str(
         qss.superstaq_backend.SuperstaQBackend(

--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -91,13 +91,13 @@ def test_qscout_compile(mock_post: MagicMock) -> None:
 
     jaqal_program = textwrap.dedent(
         """\
-                register allqubits[1]
+        register allqubits[1]
 
-                prepare_all
-                R allqubits[0] -1.5707963267948966 1.5707963267948966
-                Rz allqubits[0] -3.141592653589793
-                measure_all
-                """
+        prepare_all
+        R allqubits[0] -1.5707963267948966 1.5707963267948966
+        Rz allqubits[0] -3.141592653589793
+        measure_all
+        """
     )
 
     mock_post.return_value.json = lambda: {

--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -9,10 +9,10 @@ import qiskit
 import qiskit_superstaq as qss
 
 
-def test_provider() -> None:
+def test_provider(monkeypatch) -> None:
     ss_provider = qss.superstaq_provider.SuperstaQProvider(api_key="MY_TOKEN")
 
-    _ = os.environ.pop("SUPERSTAQ_API_KEY", None)
+    monkeypatch.delenv("SUPERSTAQ_API_KEY")
     with pytest.raises(EnvironmentError, match="api_key was not "):
         qss.superstaq_provider.SuperstaQProvider()
 


### PR DESCRIPTION
hides `os.environ["SUPERSTAQ_API_KEY"]` in `test_provider()` so that it passes whether or not the SUPERSTAQ_API_KEY environment variable is set