### PR TITLE
Automatically open an issue if the integration check fails

### DIFF
--- a/.github/integration-check-failure-issue.md
+++ b/.github/integration-check-failure-issue.md
@@ -1,0 +1,3 @@
+---
+title: Integration test failed
+---

--- a/.github/workflows/daily-integration-check.yml
+++ b/.github/workflows/daily-integration-check.yml
@@ -26,3 +26,11 @@ jobs:
       - name: Pytest integration check
         run: |
           check/pytest-daily-integration
+      - name: Create issue if integration check failed
+        if: {{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/integration-check-failure-issue.md
+          update_existing: true


### PR DESCRIPTION
Right now it only emails me as the creator of the integration check
workflow

Unfortunately Github Actions are hard to test. I just tried my best to
follow the documentation on https://github.com/JasonEtco/create-an-issue
Will be easy to test upon deploy, since qiskit-superstaq's integration
check is currently failing