### PR TITLE
Adds client-side functionality for setting IBMQ token

### DIFF
--- a/.github/workflows/daily-integration-check.yml
+++ b/.github/workflows/daily-integration-check.yml
@@ -11,6 +11,7 @@ jobs:
     name: Pytest integration check
     env:
       TEST_USER_TOKEN : ${{ secrets.TEST_USER_TOKEN }}
+      TEST_USER_IBMQ_TOKEN : ${{ secrets.TEST_USER_IBMQ_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit_superstaq/daily_integration_test.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import pytest
 import qiskit
+from applications_superstaq import SuperstaQException
 
 import qiskit_superstaq
 
@@ -13,6 +14,16 @@ def provider() -> qiskit_superstaq.superstaq_provider.SuperstaQProvider:
     token = os.environ["TEST_USER_TOKEN"]
     provider = qiskit_superstaq.superstaq_provider.SuperstaQProvider(api_key=token)
     return provider
+
+
+def test_ibmq_set_token() -> None:
+    api_token = os.environ["TEST_USER_TOKEN"]
+    ibmq_token = os.environ["TEST_USER_IBMQ_TOKEN"]
+    provider = qiskit_superstaq.superstaq_provider.SuperstaQProvider(api_key=api_token)
+    assert provider.ibmq_set_token(ibmq_token) == "Your IBM Q account token has been updated"
+
+    with pytest.raises(SuperstaQException, match="IBMQ token is invalid."):
+        assert provider.ibmq_set_token("INVALID_TOKEN")
 
 
 def test_aqt_compile(provider: qiskit_superstaq.superstaq_provider.SuperstaQProvider) -> None:

--- a/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit_superstaq/superstaq_provider.py
@@ -110,16 +110,6 @@ class SuperstaQProvider(
     def get_access_token(self) -> Optional[str]:
         return self.api_key
 
-    def set_ibm_token(self, token: str) -> None:
-        """Sets IBMQ token field for user in database.
-
-        Args:
-            token: IBMQ token string.
-
-        Returns: no returns.
-        """
-        return self._client.set_ibm_token({"ibmq_token": token})
-
     def backends(self) -> List[qss.superstaq_backend.SuperstaQBackend]:
         # needs to be fixed (#469)
         backend_names = [

--- a/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit_superstaq/superstaq_provider.py
@@ -110,6 +110,16 @@ class SuperstaQProvider(
     def get_access_token(self) -> Optional[str]:
         return self.api_key
 
+    def set_ibm_token(self, token: str) -> None:
+        """Sets IBMQ token field for user in database.
+
+        Args:
+            token: IBMQ token string.
+
+        Returns: no returns.
+        """
+        return self._client.set_ibm_token({"ibmq_token": token})
+
     def backends(self) -> List[qss.superstaq_backend.SuperstaQBackend]:
         # needs to be fixed (#469)
         backend_names = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-applications-superstaq>=0.0.10
+applications-superstaq>=0.0.11
 qiskit>=0.28.0, <0.33.0


### PR DESCRIPTION
Inherits functionality for IBMQ token endpoint from up-to-date `applications-superstaq`:

![qss-success-token](https://user-images.githubusercontent.com/18367737/148611140-19cf75b8-6494-4bc8-8006-fd3607eeeab8.png)