### PR TITLE
Changed "IBM Q" to "IBMQ", to match expected string

### DIFF
--- a/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit_superstaq/daily_integration_test.py
@@ -28,7 +28,7 @@ def test_ibmq_set_token() -> None:
     api_token = os.environ["TEST_USER_TOKEN"]
     ibmq_token = os.environ["TEST_USER_IBMQ_TOKEN"]
     provider = qiskit_superstaq.superstaq_provider.SuperstaQProvider(api_key=api_token)
-    assert provider.ibmq_set_token(ibmq_token) == "Your IBM Q account token has been updated"
+    assert provider.ibmq_set_token(ibmq_token) == "Your IBMQ account token has been updated"
 
     with pytest.raises(SuperstaQException, match="IBMQ token is invalid."):
         assert provider.ibmq_set_token("INVALID_TOKEN")


### PR DESCRIPTION
Fixes #90. Fixed expected string for successful token update.

![daily-integration](https://user-images.githubusercontent.com/18367737/151014440-9734a050-87f7-4780-bb34-e8cf984a1470.png)