### PR TITLE
FermionicSWAPGate -> ZZSwapGate

### DIFF
--- a/qiskit_superstaq/__init__.py
+++ b/qiskit_superstaq/__init__.py
@@ -4,17 +4,17 @@ from . import superstaq_backend
 from . import superstaq_job
 from . import superstaq_provider
 from ._version import __version__
-from .custom_gates import AceCR, FermionicSWAPGate, ParallelGates
+from .custom_gates import AceCR, ParallelGates, ZZSwapGate
 
 __all__ = [
     "AceCR",
     "API_URL",
     "API_VERSION",
-    "FermionicSWAPGate",
     "ParallelGates",
     "serialization",
     "superstaq_backend",
     "superstaq_job",
     "superstaq_provider",
+    "ZZSwapGate",
     "__version__",
 ]

--- a/qiskit_superstaq/custom_gates.py
+++ b/qiskit_superstaq/custom_gates.py
@@ -60,14 +60,14 @@ class AceCR(qiskit.circuit.Gate):
         return f"AceCR{self.polarity}"
 
 
-class FermionicSWAPGate(qiskit.circuit.Gate):
-    r"""The Fermionic SWAP gate, which performs the ZZ-interaction followed by a SWAP.
+class ZZSwapGate(qiskit.circuit.Gate):
+    r"""The ZZ-SWAP gate, which performs the ZZ-interaction followed by a SWAP.
 
-    Fermionic SWAPs are useful for applications like QAOA or Hamiltonian Simulation,
+    ZZ-SWAPs are useful for applications like QAOA or Hamiltonian Simulation,
     particularly on linear- or low- connectivity devices. See https://arxiv.org/pdf/2004.14970.pdf
-    for an application of Fermionic SWAP networks.
+    for an application of ZZ-SWAP networks.
 
-    The unitary for a Fermionic SWAP gate parametrized by ZZ-interaction angle :math:`\theta` is:
+    The unitary for a ZZ-SWAP gate parametrized by ZZ-interaction angle :math:`\theta` is:
 
      .. math::
 
@@ -79,7 +79,7 @@ class FermionicSWAPGate(qiskit.circuit.Gate):
         \end{bmatrix}
 
     where '.' means '0'.
-    For :math:`\theta = 0`, the Fermionic SWAP gate is just an ordinary SWAP.
+    For :math:`\theta = 0`, the ZZ-SWAP gate is just an ordinary SWAP.
     """
 
     def __init__(self, theta: float, label: Optional[str] = None) -> None:
@@ -88,13 +88,13 @@ class FermionicSWAPGate(qiskit.circuit.Gate):
             theta: ZZ-interaction angle in radians
             label: an optional label for the constructed Gate
         """
-        super().__init__("fermionic_swap", 2, [theta], label=label)
+        super().__init__("zzswap", 2, [theta], label=label)
 
-    def inverse(self) -> "FermionicSWAPGate":
-        return FermionicSWAPGate(-self.params[0])
+    def inverse(self) -> "ZZSwapGate":
+        return ZZSwapGate(-self.params[0])
 
     def _define(self) -> None:
-        qc = qiskit.QuantumCircuit(2, name="fermionic_swap")
+        qc = qiskit.QuantumCircuit(2, name="zzswap")
         qc.cx(0, 1)
         qc.cx(1, 0)
         qc.rz(self.params[0], 1)
@@ -116,11 +116,11 @@ class FermionicSWAPGate(qiskit.circuit.Gate):
         args = f"{self.params[0]}"
         if self.label:
             args += f", label='{self.label}'"
-        return f"qiskit_superstaq.FermionicSWAPGate({args})"
+        return f"qiskit_superstaq.ZZSwapGate({args})"
 
     def __str__(self) -> str:
         args = qiskit.circuit.tools.pi_check(self.params[0], ndigits=8, output="qasm")
-        return f"FermionicSWAPGate({args})"
+        return f"ZZSwapGate({args})"
 
 
 class ParallelGates(qiskit.circuit.Gate):
@@ -174,8 +174,8 @@ def custom_resolver(gate: qiskit.circuit.Gate) -> Optional[qiskit.circuit.Gate]:
         return AceCR("+-", label=gate.label)
     if gate.definition.name == "acecr_mp":
         return AceCR("-+", label=gate.label)
-    if gate.definition.name == "fermionic_swap":
-        return FermionicSWAPGate(gate.params[0], label=gate.label)
+    if gate.definition.name == "zzswap":
+        return ZZSwapGate(gate.params[0], label=gate.label)
     if gate.definition.name == "parallel_gates":
         component_gates = [custom_resolver(inst) or inst for inst, _, _ in gate.definition]
         return ParallelGates(*component_gates, label=gate.label)

--- a/qiskit_superstaq/custom_gates_test.py
+++ b/qiskit_superstaq/custom_gates_test.py
@@ -37,15 +37,15 @@ def test_acecr() -> None:
         _ = qiskit_superstaq.AceCR("++")
 
 
-def test_fermionic_swap() -> None:
-    gate = qiskit_superstaq.FermionicSWAPGate(1.23)
+def test_zz_swap() -> None:
+    gate = qiskit_superstaq.ZZSwapGate(1.23)
     _check_gate_definition(gate)
-    assert repr(gate) == "qiskit_superstaq.FermionicSWAPGate(1.23)"
-    assert str(gate) == "FermionicSWAPGate(1.23)"
+    assert repr(gate) == "qiskit_superstaq.ZZSwapGate(1.23)"
+    assert str(gate) == "ZZSwapGate(1.23)"
 
-    gate = qiskit_superstaq.FermionicSWAPGate(4.56, label="label")
-    assert repr(gate) == "qiskit_superstaq.FermionicSWAPGate(4.56, label='label')"
-    assert str(gate) == "FermionicSWAPGate(4.56)"
+    gate = qiskit_superstaq.ZZSwapGate(4.56, label="label")
+    assert repr(gate) == "qiskit_superstaq.ZZSwapGate(4.56, label='label')"
+    assert str(gate) == "ZZSwapGate(4.56)"
 
 
 def test_parallel_gates() -> None:
@@ -75,11 +75,11 @@ def test_parallel_gates() -> None:
 
     gate = qiskit_superstaq.ParallelGates(
         qiskit.circuit.library.XGate(),
-        qiskit_superstaq.FermionicSWAPGate(1.23),
+        qiskit_superstaq.ZZSwapGate(1.23),
         qiskit.circuit.library.ZGate(),
         label="label",
     )
-    assert str(gate) == "ParallelGates(x, fermionic_swap(1.23), z)"
+    assert str(gate) == "ParallelGates(x, zzswap(1.23), z)"
     _check_gate_definition(gate)
 
     # confirm gates are applied to disjoint qubits
@@ -96,7 +96,7 @@ def test_parallel_gates() -> None:
 def test_custom_resolver() -> None:
     gates = [
         qiskit_superstaq.AceCR("+-"),
-        qiskit_superstaq.FermionicSWAPGate(1.23),
+        qiskit_superstaq.ZZSwapGate(1.23),
         qiskit_superstaq.ParallelGates(
             qiskit.circuit.library.RXGate(4.56),
             qiskit.circuit.library.CXGate(),

--- a/qiskit_superstaq/serialization_test.py
+++ b/qiskit_superstaq/serialization_test.py
@@ -10,9 +10,9 @@ import qiskit_superstaq
 
 
 def test_assign_unique_inst_names() -> None:
-    inst_0 = qiskit_superstaq.FermionicSWAPGate(0.1)
-    inst_1 = qiskit_superstaq.FermionicSWAPGate(0.2)
-    inst_2 = qiskit_superstaq.FermionicSWAPGate(0.1)
+    inst_0 = qiskit_superstaq.ZZSwapGate(0.1)
+    inst_1 = qiskit_superstaq.ZZSwapGate(0.2)
+    inst_2 = qiskit_superstaq.ZZSwapGate(0.1)
 
     circuit = qiskit.QuantumCircuit(4)
     circuit.append(inst_0, [0, 1])
@@ -23,10 +23,10 @@ def test_assign_unique_inst_names() -> None:
     circuit.rxx(1.2, 1, 2)
 
     expected_inst_names = [
-        "fermionic_swap",
-        "fermionic_swap_1",
-        "fermionic_swap",
-        "fermionic_swap_1",
+        "zzswap",
+        "zzswap_1",
+        "zzswap",
+        "zzswap_1",
         "rxx",
         "rxx",
     ]
@@ -43,24 +43,24 @@ def test_circuit_serialization() -> None:
     circuit_1 = qiskit.QuantumCircuit(4)
     circuit_1.append(qiskit_superstaq.AceCR("+-"), [0, 1])
     circuit_1.append(qiskit_superstaq.AceCR("-+"), [1, 2])
-    circuit_1.append(qiskit_superstaq.FermionicSWAPGate(0.75), [2, 0])
+    circuit_1.append(qiskit_superstaq.ZZSwapGate(0.75), [2, 0])
     circuit_1.append(
         qiskit_superstaq.ParallelGates(
-            qiskit_superstaq.FermionicSWAPGate(3.09),
+            qiskit_superstaq.ZZSwapGate(3.09),
             qiskit.circuit.library.RXXGate(0.1),
         ),
         [1, 2, 0, 3],
     )
     circuit_1.append(
         qiskit_superstaq.ParallelGates(
-            qiskit_superstaq.FermionicSWAPGate(3.09),
+            qiskit_superstaq.ZZSwapGate(3.09),
             qiskit.circuit.library.RXXGate(0.2),
         ),
         [0, 3, 2, 1],
     )
     circuit_1.append(
         qiskit_superstaq.ParallelGates(
-            qiskit_superstaq.FermionicSWAPGate(3.09),
+            qiskit_superstaq.ZZSwapGate(3.09),
             qiskit.circuit.library.RXXGate(0.1),
         ),
         [0, 1, 3, 2],


### PR DESCRIPTION
gate renamed to avoid conflicts w/ prior usage of "Fermionic SWAP"

parity: SupertechLabs/cirq-superstaq#171