### PR TITLE
Use `ibmq_pulse` parameter

### DIFF
--- a/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit_superstaq/superstaq_backend.py
@@ -11,10 +11,11 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 
 import qiskit
-import requests
+
+# import requests
 
 import qiskit_superstaq as qss
 
@@ -60,38 +61,26 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
         )
 
     def run(
-        self, circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]], **kwargs: int
+        self,
+        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        shots: Optional[int] = 1000,
+        ibmq_pulse: Optional[bool] = None,
+        **kwargs: int
     ) -> "qss.superstaq_job.SuperstaQJob":
 
         if isinstance(circuits, qiskit.QuantumCircuit):
             circuits = [circuits]
 
-        superstaq_json = {
-            "qiskit_circuits": qss.serialization.serialize_circuits(circuits),
-            "backend": self.name(),
-            "shots": kwargs.get("shots"),
-            "ibmq_token": kwargs.get("ibmq_token"),
-            "ibmq_hub": kwargs.get("ibmq_hub"),
-            "ibmq_group": kwargs.get("ibmq_group"),
-            "ibmq_project": kwargs.get("ibmq_project"),
-            "ibmq_pulse": kwargs.get("ibmq_pulse"),
-        }
+        qiskit_circuits = qss.serialization.serialize_circuits(circuits)
 
-        res = requests.post(
-            f"{self.remote_host}/{qss.API_VERSION}/jobs",
-            json=superstaq_json,
-            headers=self._provider._http_headers(),
-            verify=(self.remote_host == qss.API_URL),
+        result = self._provider._client.create_job(
+            serialized_circuits={"qiskit_circuits": qiskit_circuits},
+            repetitions=shots,
+            target=self.name(),
+            ibmq_pulse=ibmq_pulse,
         )
 
-        res.raise_for_status()
-        response = res.json()
-        if "job_ids" not in response:
-            raise Exception
-
-        #  we make a virtual job_id that aggregates all of the individual jobs
-        # into a single one, that comma-separates the individual jobs:
-        job_id = ",".join(response["job_ids"])
+        job_id = result["job_ids"][0]
         job = qss.superstaq_job.SuperstaQJob(self, job_id)
 
         return job

--- a/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit_superstaq/superstaq_backend.py
@@ -79,7 +79,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
         #  we make a virtual job_id that aggregates all of the individual jobs
         # into a single one, that comma-separates the individual jobs:
-        job_id = ",".join(result["job_ids"]) 
+        job_id = ",".join(result["job_ids"])
         job = qss.superstaq_job.SuperstaQJob(self, job_id)
 
         return job

--- a/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit_superstaq/superstaq_backend.py
@@ -15,8 +15,6 @@ from typing import Any, List, Optional, Union
 
 import qiskit
 
-# import requests
-
 import qiskit_superstaq as qss
 
 
@@ -63,9 +61,8 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
     def run(
         self,
         circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
-        shots: Optional[int] = 1000,
+        shots: int,
         ibmq_pulse: Optional[bool] = None,
-        **kwargs: int
     ) -> "qss.superstaq_job.SuperstaQJob":
 
         if isinstance(circuits, qiskit.QuantumCircuit):

--- a/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit_superstaq/superstaq_backend.py
@@ -77,7 +77,9 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
             ibmq_pulse=ibmq_pulse,
         )
 
-        job_id = result["job_ids"][0]
+        #  we make a virtual job_id that aggregates all of the individual jobs
+        # into a single one, that comma-separates the individual jobs:
+        job_id = ",".join(result["job_ids"]) 
         job = qss.superstaq_job.SuperstaQJob(self, job_id)
 
         return job


### PR DESCRIPTION
Also updates `SuperstaQBackend.run` method to use `applications-superstaq` (i.e., the `create_job` method):

![backend-success](https://user-images.githubusercontent.com/18367737/153509683-fb181a43-ec0c-4593-8403-52126c4bd788.png)

![backend-fail](https://user-images.githubusercontent.com/18367737/153509798-1fd1e73e-462a-4446-953c-065d84a024b2.png)

