### PR TITLE
Change expected `z` gate from `cq_compile` to `rz(pi)`

### DIFF
--- a/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit_superstaq/daily_integration_test.py
@@ -98,7 +98,7 @@ def test_cq_compile(provider: qss.SuperstaQProvider) -> None:
     circuit.h(0)
     expected = qiskit.QuantumCircuit(1)
     expected.append(GR(1, -0.25 * np.pi, 0.5 * np.pi), [0])
-    expected.z(0)
+    expected.rz(np.pi, 0)
     expected.append(GR(1, 0.25 * np.pi, 0.5 * np.pi), [0])
     assert provider.cq_compile(circuit).circuit == expected
     assert provider.cq_compile([circuit]).circuits == [expected]


### PR DESCRIPTION
`z` gate is not supported as a native gate.