### PR TITLE
Added `qiskit_to_cirq` function to Provider

### DIFF
--- a/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit_superstaq/superstaq_provider.py
@@ -272,3 +272,14 @@ class SuperstaQProvider(
         if isinstance(circuits, qiskit.QuantumCircuit):
             return pulses[0]
         return pulses
+
+    def qiskit_to_cirq(
+        self,
+        qiskit_circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+    ) -> str:
+        """Converts the given `qiskit.QuantumCircuit`s to (serialized) `cirq.Circuit`s."""
+        serialized_circuits = qss.serialization.serialize_circuits(qiskit_circuits)
+
+        json_dict = self._client.qiskit_to_cirq({"qiskit_circuits": serialized_circuits})
+
+        return json_dict["cirq_circuits"]

--- a/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit_superstaq/superstaq_provider_test.py
@@ -81,6 +81,19 @@ def test_get_balance() -> None:
     assert ss_provider.get_balance(pretty_output=False) == 12345.6789
 
 
+@patch(
+    "applications_superstaq.superstaq_client._SuperstaQClient.qiskit_to_cirq",
+)
+def test_service_qiskit_to_cirq(mock_qiskit_to_cirq: MagicMock) -> None:
+    provider = qss.SuperstaQProvider(api_key="MY_TOKEN")
+    qc = qiskit.QuantumCircuit(8)
+    qc.cz(4, 5)
+    mock_qiskit_to_cirq.return_value = {
+        "cirq_circuits": "SerializedQuantumCircuit",
+    }
+    assert isinstance(provider.qiskit_to_cirq(qc), str)
+
+
 @patch("requests.post")
 def test_aqt_compile(mock_post: MagicMock) -> None:
     provider = qss.SuperstaQProvider(api_key="MY_TOKEN")


### PR DESCRIPTION
Currently the function returns the serialized `cirq.Circuit`s -- this is to avoid needing to import cirq and cirq-superstaq within qiskit-superstaq. The deserialization can be done within SupermarQ.